### PR TITLE
API to filter expense_groups by exported_at date

### DIFF
--- a/apps/fyle/urls.py
+++ b/apps/fyle/urls.py
@@ -17,11 +17,13 @@ from django.urls import path
 
 from .views import ExpenseGroupView, ExpenseGroupByIdView, ExpenseGroupScheduleView, ExpenseView, EmployeeView, \
     CategoryView, CostCenterView, ProjectView, ExpenseFieldsView, ExpenseCustomFieldsView, \
-    ExpenseGroupSettingsView, RefreshFyleDimensionView, SyncFyleDimensionView, ExpenseGroupCountView
+    ExpenseGroupSettingsView, RefreshFyleDimensionView, SyncFyleDimensionView, ExpenseGroupCountView,\
+    ExpenseGroupsFilterView
 
 urlpatterns = [
     path('expense_groups/', ExpenseGroupView.as_view(), name='expense-groups'),
     path('expense_groups/count/', ExpenseGroupCountView.as_view(), name='expense-groups-count'),
+    path('expense_groups/filter/', ExpenseGroupsFilterView.as_view(), name='expense-groups-filter'),
     path('expense_group_settings/', ExpenseGroupSettingsView.as_view(), name='expense-group-settings'),
     path('expense_groups/trigger/', ExpenseGroupScheduleView.as_view()),
     path('expense_groups/<int:expense_group_id>/', ExpenseGroupByIdView.as_view(), name='expense-group-by-id'),

--- a/apps/fyle/views.py
+++ b/apps/fyle/views.py
@@ -96,6 +96,21 @@ class ExpenseGroupCountView(generics.ListAPIView):
         )
 
 
+class ExpenseGroupsFilterView(generics.ListAPIView):
+    """
+    Filter Expense groups by exported_at date
+    """
+    serializer_class = ExpenseGroupSerializer
+
+    def get_queryset(self):
+        start_date = (self.request.query_params.get('start_date'))
+        end_date = (self.request.query_params.get('end_date'))
+
+        return ExpenseGroup.objects.filter(
+            workspace_id=self.kwargs['workspace_id'], exported_at__range=[start_date, end_date]
+        )
+
+
 class ExpenseGroupScheduleView(generics.CreateAPIView):
     """
     Create expense group schedule


### PR DESCRIPTION
API PATH with query_params 
`api/workspaces/<id>/fyle/expense_groups/filter/?start_date=2022-01-01&end_date=2022-03-24`

This API returns a paginated response 