### PR TITLE
variables reinitialised in tasks

### DIFF
--- a/apps/fyle/tasks.py
+++ b/apps/fyle/tasks.py
@@ -122,6 +122,8 @@ def async_create_expense_groups(workspace_id: int, fund_source: List[str], task_
             if expenses:
                 workspace.last_synced_at = datetime.now()
                 reimbursable_expense_count += len(expenses)
+                
+            settled_at, approved_at, last_paid_at = None, None, None
 
             if 'CCC' in fund_source:
                 


### PR DESCRIPTION
I checked with only reimbursable and only ccc expenses, in that case, the query works fine, but fails when we have both reimbursable and CCC expenses in same report.
IMO the issue was because of the variable initialization, some of the variables settled_at, approved_at, last_paid_at were initialized in the reimbursable block but not set to None for ccc block and hence these values got carried in ccc's query leading to a wrong number of imports.