### PR TITLE
fix: Bill Number (Add Safety)

### DIFF
--- a/apps/quickbooks_online/models.py
+++ b/apps/quickbooks_online/models.py
@@ -191,6 +191,10 @@ def get_bill_number(expense_group: ExpenseGroup):
         bill_number_field = 'expense_number'
 
     bill_number = expense_group.expenses.first().__getattribute__(bill_number_field)
+
+    count = Bill.objects.filter(bill_number=bill_number, expense_group__workspace_id=expense_group.workspace.id).count()
+    if count > 0:
+        bill_number = '{} - {}'.format(bill_number, count)
     return bill_number
 
 


### PR DESCRIPTION
### Description
Add Safety Check for Bills
If Bill Number exists in DB then add count to it

## Clickup
[ADMIN | ARR $3,598 | QBO Error - Duplicate Document Number](https://app.clickup.com/t/86cwk7a1e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the uniqueness of bill numbers by appending a count when duplicates are found within the same workspace. 

- **Bug Fixes**
	- Improved logic for retrieving bill numbers to prevent duplication issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->