### PR TITLE
fix: change the `report_title` option to `report_name`

### DIFF
--- a/apps/fyle/constants.py
+++ b/apps/fyle/constants.py
@@ -1,7 +1,7 @@
 DEFAULT_FYLE_CONDITIONS = [
     {'field_name': 'employee_email', 'type': 'SELECT', 'is_custom': False},
     {'field_name': 'claim_number', 'type': 'TEXT', 'is_custom': False},
-    {'field_name': 'report_title', 'type': 'TEXT', 'is_custom': False},
+    {'field_name': 'report_name', 'type': 'TEXT', 'is_custom': False},
     {'field_name': 'spent_at', 'type': 'DATE', 'is_custom': False},
     {'field_name': 'category', 'type': 'SELECT', 'is_custom': False},
 ]


### PR DESCRIPTION
## Clickup
https://app.clickup.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the field name from 'report_title' to 'report_name' for improved clarity in reporting conditions. 

This change enhances the user experience by ensuring consistency in terminology across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->