### PR TITLE
fix: add default values

### DIFF
--- a/apps/fyle/models.py
+++ b/apps/fyle/models.py
@@ -171,6 +171,7 @@ class Expense(models.Model):
                 'file_ids': expense['file_ids'],
                 'spent_at': expense['spent_at'],
                 'posted_at': expense['posted_at'],
+                'is_posted_at_null': expense['is_posted_at_null'],
                 'fund_source': SOURCE_ACCOUNT_MAP[expense['source_account_type']],
                 'verified_at': expense['verified_at'],
                 'custom_properties': expense['custom_properties'],


### PR DESCRIPTION
### Description
- fix for default value of is posted at null

## Clickup
- https://app.clickup.com/t/86cx0x4v9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced expense object creation with the addition of the `is_posted_at_null` attribute, improving tracking of posted dates for expenses. 

- **Bug Fixes**
	- Improved handling of expense updates to ensure accurate representation of the `posted_at` date status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->