### PR TITLE
fix: delete `expense_attributes_deletion_cache` in workspace reset

### DIFF
--- a/sql/functions/reset-workspace.sql
+++ b/sql/functions/reset-workspace.sql
@@ -240,6 +240,12 @@ BEGIN
   GET DIAGNOSTICS rcount = ROW_COUNT;
   RAISE NOTICE 'Deleted % django_q_schedule', rcount;
 
+  DELETE
+  FROM expense_attributes_deletion_cache 
+  WHERE workspace_id = _workspace_id;
+  GET DIAGNOSTICS rcount = ROW_COUNT;
+  RAISE NOTICE 'Deleted % expense_attributes_deletion_cache', rcount;
+
 --   DELETE
 --   FROM auth_tokens aut
 --   WHERE aut.user_id IN (


### PR DESCRIPTION
## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced workspace reset functionality by adding deletion of records from the `expense_attributes_deletion_cache` table.

- **Bug Fixes**
	- Improved cleanup process for workspace-related data, ensuring more comprehensive data removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->