### PR TITLE
feat: patch `/integrations` on token expiry

### DIFF
--- a/apps/quickbooks_online/actions.py
+++ b/apps/quickbooks_online/actions.py
@@ -57,6 +57,9 @@ def get_preferences(workspace_id: int):
             qbo_credentials.refresh_token = None
             qbo_credentials.is_expired = True
             qbo_credentials.save()
+
+            patch_integration_settings(workspace_id, is_token_expired=True)
+
         return Response(data={'message': 'Invalid token or Quickbooks Online connection expired'}, status=status.HTTP_400_BAD_REQUEST)
 
 

--- a/apps/quickbooks_online/exceptions.py
+++ b/apps/quickbooks_online/exceptions.py
@@ -3,6 +3,7 @@ import logging
 import traceback
 
 from fyle.platform.exceptions import InvalidTokenError as FyleInvalidTokenError
+from apps.workspaces.actions import patch_integration_settings
 from qbosdk.exceptions import InternalServerError, InvalidTokenError, WrongParamsError
 
 from apps.fyle.actions import update_failed_expenses
@@ -29,6 +30,8 @@ def handle_quickbooks_error(exception, expense_group: ExpenseGroup, task_log: Ta
                 qbo_credentials.is_expired = True
                 qbo_credentials.refresh_token = None
                 qbo_credentials.save()
+                patch_integration_settings(expense_group.workspace_id, is_token_expired=True)
+
         errors = response
     else:
         quickbooks_errors = response['Fault']['Error']
@@ -114,6 +117,8 @@ def handle_qbo_exceptions(bill_payment=False):
                     qbo_credentials.is_expired = True
                     qbo_credentials.refresh_token = None
                     qbo_credentials.save()
+
+                    patch_integration_settings(expense_group.workspace_id, is_token_expired=True)
 
                 task_log.save()
 

--- a/apps/workspaces/actions.py
+++ b/apps/workspaces/actions.py
@@ -122,6 +122,8 @@ def connect_qbo_oauth(refresh_token, realm_id, workspace_id):
     if workspace.onboarding_state == 'COMPLETE':
         post_to_integration_settings(workspace_id, True)
 
+    patch_integration_settings(workspace_id, is_token_expired=False)
+
     # Return the QBO credentials as serialized data
     return Response(data=QBOCredentialSerializer(qbo_credentials).data, status=status.HTTP_200_OK)
 

--- a/tests/test_quickbooks_online/test_views.py
+++ b/tests/test_quickbooks_online/test_views.py
@@ -64,20 +64,31 @@ def test_get_company_preference(mocker, api_client, test_connection, db):
     assert response['Id'] == '1'
 
 
-def test_get_company_preference_exceptions(api_client, test_connection, db):
+def test_get_company_preference_exceptions(api_client, test_connection, mocker, db):
     access_token = test_connection.access_token
     url = '/api/workspaces/3/qbo/preferences/'
 
     api_client.credentials(HTTP_AUTHORIZATION='Bearer {}'.format(access_token))
+
+    mocked_patch = mock.MagicMock()
+    mocker.patch('apps.quickbooks_online.actions.patch_integration_settings', side_effect=mocked_patch)
 
     with mock.patch('apps.quickbooks_online.utils.QBOConnector.get_company_info') as mock_call:
         mock_call.side_effect = WrongParamsError(msg='wrong params', response='invalid_params')
         response = api_client.get(url)
         assert response.status_code == 400
 
+        args, kwargs = mocked_patch.call_args
+        assert args[0] == 3
+        assert kwargs['is_token_expired'] == True
+
         mock_call.side_effect = InvalidTokenError(msg='Invalid token, try to refresh it', response='Invalid token, try to refresh it')
         response = api_client.get(url)
         assert response.status_code == 400
+
+        args, kwargs = mocked_patch.call_args
+        assert args[0] == 3
+        assert kwargs['is_token_expired'] == True
 
         mock_call.side_effect = QBOCredential.DoesNotExist()
         response = api_client.get(url)


### PR DESCRIPTION
### Description
Whenever the QBO token expires, do a PATCH call with `is_token_expired` as `true` to integration settings API.

## Clickup
https://app.clickup.com/t/86cxhfutt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for QuickBooks Online integrations so that expired tokens are now automatically detected and managed.
	- Ensured integration settings update appropriately upon both token expiration and successful connection, leading to improved stability and a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->