### PR TITLE
feat: patch `/integrations` on export errors and token expiry

### DIFF
--- a/apps/fyle/helpers.py
+++ b/apps/fyle/helpers.py
@@ -50,7 +50,6 @@ def patch_request(url, body, refresh_token=None):
     }
     if refresh_token:
         access_token = get_access_token(refresh_token)
-
         api_headers['Authorization'] = 'Bearer {0}'.format(access_token)
 
     response = requests.patch(url, headers=api_headers, data=json.dumps(body))

--- a/apps/fyle/helpers.py
+++ b/apps/fyle/helpers.py
@@ -40,6 +40,27 @@ def post_request(url, body, refresh_token=None):
         raise Exception(response.text)
 
 
+def patch_request(url, body, refresh_token=None):
+    """
+    Create a HTTP patch request.
+    """
+    access_token = None
+    api_headers = {
+        'content-type': 'application/json',
+    }
+    if refresh_token:
+        access_token = get_access_token(refresh_token)
+
+        api_headers['Authorization'] = 'Bearer {0}'.format(access_token)
+
+    response = requests.patch(url, headers=api_headers, data=json.dumps(body))
+
+    if response.status_code in [200, 201]:
+        return json.loads(response.text)
+    else:
+        raise Exception(response.text)
+
+
 def get_request(url, params, refresh_token):
     """
     Create a HTTP get request.

--- a/apps/mappings/exceptions.py
+++ b/apps/mappings/exceptions.py
@@ -7,6 +7,7 @@ from fyle.platform.exceptions import (
     WrongParamsError,
     RetryException
 )
+from fyle_qbo_api.utils import invalidate_qbo_credentials
 from qbosdk.exceptions import InvalidTokenError as QBOInvalidTokenError
 from qbosdk.exceptions import WrongParamsError as QBOWrongParamsError
 
@@ -44,6 +45,7 @@ def handle_import_exceptions(task_name):
             except (QBOWrongParamsError, QBOInvalidTokenError) as exception:
                 error['message'] = 'QBO token expired'
                 error['response'] = exception.__dict__
+                invalidate_qbo_credentials(workspace_id)
 
             except Exception:
                 response = traceback.format_exc()
@@ -95,6 +97,7 @@ def handle_import_exceptions_v2(func):
             error['alert'] = False
             error['response'] = exception.__dict__
             import_log.status = 'FAILED'
+            invalidate_qbo_credentials(workspace_id)
 
         except Exception:
             response = traceback.format_exc()

--- a/apps/quickbooks_online/actions.py
+++ b/apps/quickbooks_online/actions.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 
 from django.conf import settings
 from django.db.models import Q
+from apps.workspaces.actions import patch_integration_settings
 from django_q.tasks import Chain
 from fyle_accounting_mappings.models import MappingSetting
 from qbosdk.exceptions import InvalidTokenError, WrongParamsError
@@ -35,6 +36,8 @@ def update_last_export_details(workspace_id):
     last_export_detail.total_expense_groups_count = failed_exports + successful_exports
     last_export_detail.save()
 
+    patch_integration_settings(workspace_id, errors=failed_exports)
+
     return last_export_detail
 
 
@@ -54,6 +57,9 @@ def get_preferences(workspace_id: int):
             qbo_credentials.refresh_token = None
             qbo_credentials.is_expired = True
             qbo_credentials.save()
+
+            patch_integration_settings(workspace_id, is_token_expired=True)
+
         return Response(data={'message': 'Invalid token or Quickbooks Online connection expired'}, status=status.HTTP_400_BAD_REQUEST)
 
 

--- a/apps/quickbooks_online/actions.py
+++ b/apps/quickbooks_online/actions.py
@@ -3,7 +3,8 @@ from datetime import datetime, timezone
 
 from django.conf import settings
 from django.db.models import Q
-from apps.workspaces.actions import patch_integration_settings
+from fyle_qbo_api.utils import invalidate_qbo_credentials
+from fyle_qbo_api.utils import patch_integration_settings
 from django_q.tasks import Chain
 from fyle_accounting_mappings.models import MappingSetting
 from qbosdk.exceptions import InvalidTokenError, WrongParamsError
@@ -53,13 +54,7 @@ def get_preferences(workspace_id: int):
     except QBOCredential.DoesNotExist:
         return Response(data={'message': 'QBO credentials not found in workspace'}, status=status.HTTP_400_BAD_REQUEST)
     except (WrongParamsError, InvalidTokenError):
-        if qbo_credentials:
-            qbo_credentials.refresh_token = None
-            qbo_credentials.is_expired = True
-            qbo_credentials.save()
-
-            patch_integration_settings(workspace_id, is_token_expired=True)
-
+        invalidate_qbo_credentials(workspace_id, qbo_credentials)
         return Response(data={'message': 'Invalid token or Quickbooks Online connection expired'}, status=status.HTTP_400_BAD_REQUEST)
 
 

--- a/apps/quickbooks_online/exceptions.py
+++ b/apps/quickbooks_online/exceptions.py
@@ -3,6 +3,7 @@ import logging
 import traceback
 
 from fyle.platform.exceptions import InvalidTokenError as FyleInvalidTokenError
+from apps.workspaces.actions import patch_integration_settings
 from qbosdk.exceptions import InternalServerError, InvalidTokenError, WrongParamsError
 
 from apps.fyle.actions import update_failed_expenses
@@ -29,6 +30,8 @@ def handle_quickbooks_error(exception, expense_group: ExpenseGroup, task_log: Ta
                 qbo_credentials.is_expired = True
                 qbo_credentials.refresh_token = None
                 qbo_credentials.save()
+                patch_integration_settings(expense_group.workspace_id, is_token_expired=True)
+
         errors = response
     else:
         quickbooks_errors = response['Fault']['Error']
@@ -114,6 +117,8 @@ def handle_qbo_exceptions(bill_payment=False):
                     qbo_credentials.is_expired = True
                     qbo_credentials.refresh_token = None
                     qbo_credentials.save()
+
+                    patch_integration_settings(expense_group.workspace_id, is_token_expired=True)
 
                 task_log.save()
 

--- a/apps/quickbooks_online/exceptions.py
+++ b/apps/quickbooks_online/exceptions.py
@@ -3,7 +3,7 @@ import logging
 import traceback
 
 from fyle.platform.exceptions import InvalidTokenError as FyleInvalidTokenError
-from apps.workspaces.actions import patch_integration_settings
+from fyle_qbo_api.utils import invalidate_qbo_credentials
 from qbosdk.exceptions import InternalServerError, InvalidTokenError, WrongParamsError
 
 from apps.fyle.actions import update_failed_expenses
@@ -25,12 +25,7 @@ def handle_quickbooks_error(exception, expense_group: ExpenseGroup, task_log: Ta
     if 'Fault' not in response:
         logger.info(response)
         if 'error' in response and response['error'] == 'invalid_grant':
-            qbo_credentials: QBOCredential = QBOCredential.objects.filter(workspace_id=expense_group.workspace_id).first()
-            if qbo_credentials:
-                qbo_credentials.is_expired = True
-                qbo_credentials.refresh_token = None
-                qbo_credentials.save()
-                patch_integration_settings(expense_group.workspace_id, is_token_expired=True)
+            invalidate_qbo_credentials(expense_group.workspace_id)
 
         errors = response
     else:
@@ -109,16 +104,7 @@ def handle_qbo_exceptions(bill_payment=False):
                 detail = {'expense_group_id': expense_group.id, 'message': 'QBO Account not connected / token expired'}
                 task_log.status = 'FAILED'
                 task_log.detail = detail
-                qbo_credentials = QBOCredential.objects.filter(
-                    workspace_id=expense_group.workspace_id
-                ).first()
-
-                if qbo_credentials:
-                    qbo_credentials.is_expired = True
-                    qbo_credentials.refresh_token = None
-                    qbo_credentials.save()
-
-                    patch_integration_settings(expense_group.workspace_id, is_token_expired=True)
+                invalidate_qbo_credentials(expense_group.workspace_id)
 
                 task_log.save()
 

--- a/apps/quickbooks_online/tasks.py
+++ b/apps/quickbooks_online/tasks.py
@@ -9,6 +9,7 @@ from django.db import transaction
 from django.utils import timezone as django_timezone
 from fyle_accounting_mappings.models import DestinationAttribute, EmployeeMapping, ExpenseAttribute, Mapping
 from fyle_integrations_platform_connector import PlatformConnector
+from fyle_qbo_api.utils import invalidate_qbo_credentials
 from qbosdk.exceptions import InvalidTokenError, WrongParamsError
 
 from apps.fyle.actions import update_expenses_in_progress
@@ -726,8 +727,16 @@ def check_qbo_object_status(workspace_id):
                     bill.paid_on_qbo = True
                     bill.payment_synced = True
                     bill.save()
-    except (WrongParamsError, InvalidTokenError) as exception:
+
+    except QBOCredential.DoesNotExist:
+        logger.info(f'QBO credentials not found for {workspace_id = }:', )
+
+    except WrongParamsError as exception:
+        logger.info('Wrong parameters passed in workspace_id - %s %s', workspace_id, {'error': exception.response})
+
+    except InvalidTokenError as exception:
         logger.info('QBO token expired workspace_id - %s %s', workspace_id, {'error': exception.response})
+        invalidate_qbo_credentials(workspace_id, qbo_credentials)
 
 
 def process_reimbursements(workspace_id):
@@ -797,8 +806,13 @@ def async_sync_accounts(workspace_id):
 
         qbo_connection = QBOConnector(credentials_object=qbo_credentials, workspace_id=workspace_id)
         qbo_connection.sync_accounts()
+
+    except QBOCredential.DoesNotExist:
+        logger.info(f'QBO credentials not found for {workspace_id = }:', )
+
     except (WrongParamsError, InvalidTokenError) as exception:
         logger.info('QBO token expired workspace_id - %s %s', workspace_id, {'error': exception.response})
+        invalidate_qbo_credentials(workspace_id, qbo_credentials)
 
 
 def update_expense_and_post_summary(in_progress_expenses: List[Expense], workspace_id: int, fund_source: str) -> None:

--- a/apps/workspaces/actions.py
+++ b/apps/workspaces/actions.py
@@ -15,7 +15,7 @@ from rest_framework.response import Response
 from rest_framework.views import status
 
 from apps.fyle.actions import update_failed_expenses
-from apps.fyle.helpers import get_cluster_domain, post_request
+from apps.fyle.helpers import get_cluster_domain, patch_request, post_request
 from apps.fyle.models import ExpenseGroup, ExpenseGroupSettings
 from apps.fyle.queue import async_post_accounting_export_summary
 from apps.quickbooks_online.queue import (
@@ -121,6 +121,8 @@ def connect_qbo_oauth(refresh_token, realm_id, workspace_id):
 
     if workspace.onboarding_state == 'COMPLETE':
         post_to_integration_settings(workspace_id, True)
+
+    patch_integration_settings(workspace_id, is_token_expired=False)
 
     # Return the QBO credentials as serialized data
     return Response(data=QBOCredentialSerializer(qbo_credentials).data, status=status.HTTP_200_OK)
@@ -247,6 +249,29 @@ def post_to_integration_settings(workspace_id: int, active: bool):
         post_request(url, payload, refresh_token)
     except Exception as error:
         logger.error(error)
+
+
+def patch_integration_settings(workspace_id: int, errors: int = None, is_token_expired = None):
+    """
+    Patch integration settings
+    """
+
+    refresh_token = FyleCredential.objects.get(workspace_id=workspace_id).refresh_token
+    url = '{}/integrations/'.format(settings.INTEGRATIONS_SETTINGS_API)
+    payload = {
+        'tpa_name': 'Fyle Quickbooks Integration',
+    }
+
+    if errors is not None:
+        payload['errors_count'] = errors
+
+    if is_token_expired is not None:
+        payload['is_token_expired'] = is_token_expired
+
+    try:
+        patch_request(url, payload, refresh_token)
+    except Exception as error:
+        logger.error(error, exc_info=True)
 
 
 def export_to_qbo(workspace_id, export_mode=None, expense_group_ids=[], is_direct_export:bool = False):

--- a/fyle_qbo_api/utils.py
+++ b/fyle_qbo_api/utils.py
@@ -1,5 +1,14 @@
+import logging
+from django.conf import settings
 from rest_framework.serializers import ValidationError
 from rest_framework.views import Response
+
+from apps.fyle.helpers import patch_request
+from apps.workspaces.models import FyleCredential, QBOCredential
+
+
+logger = logging.getLogger(__name__)
+logger.level = logging.INFO
 
 
 def assert_valid(condition: bool, message: str) -> Response or None:
@@ -22,3 +31,41 @@ class LookupFieldMixin:
             filter_kwargs = {self.lookup_field: lookup_value}
             queryset = queryset.filter(**filter_kwargs)
         return super().filter_queryset(queryset)
+
+
+def patch_integration_settings(workspace_id: int, errors: int = None, is_token_expired = None):
+    """
+    Patch integration settings
+    """
+
+    refresh_token = FyleCredential.objects.get(workspace_id=workspace_id).refresh_token
+    url = '{}/integrations/'.format(settings.INTEGRATIONS_SETTINGS_API)
+    payload = {
+        'tpa_name': 'Fyle Quickbooks Integration',
+    }
+
+    if errors is not None:
+        payload['errors_count'] = errors
+
+    if is_token_expired is not None:
+        payload['is_token_expired'] = is_token_expired
+
+    try:
+        patch_request(url, payload, refresh_token)
+    except Exception as error:
+        logger.error(error, exc_info=True)
+
+
+def invalidate_qbo_credentials(workspace_id, qbo_credentials=None):
+    try:
+        if not qbo_credentials:
+            qbo_credentials = QBOCredential.get_active_qbo_credentials(workspace_id)
+
+        if qbo_credentials:
+            if not qbo_credentials.is_expired:
+                patch_integration_settings(workspace_id, is_token_expired=True)
+            qbo_credentials.refresh_token = None
+            qbo_credentials.is_expired = True
+            qbo_credentials.save()
+    except QBOCredential.DoesNotExist:
+        logger.info(f'QBO credentials not found for {workspace_id = }:', )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,33 @@
+
+from unittest.mock import MagicMock
+from fyle_qbo_api.utils import invalidate_qbo_credentials
+from apps.workspaces.models import QBOCredential
+
+
+def test_invalidate_qbo_credentials(mocker, db):
+    workspace_id = 3
+    qbo_credentials = QBOCredential.get_active_qbo_credentials(workspace_id=workspace_id)
+
+    mocked_patch = MagicMock()
+    mocker.patch('fyle_qbo_api.utils.patch_integration_settings', side_effect=mocked_patch)
+
+    # Should not fail if qbo_credentials was not found
+    qbo_credentials.delete()
+    invalidate_qbo_credentials(workspace_id)
+    assert not mocked_patch.called
+
+    # Should not call patch_integration_settings if qbo_credentials.is_expired is True
+    qbo_credentials.is_expired = True
+    qbo_credentials.save()
+    invalidate_qbo_credentials(workspace_id)
+    assert not mocked_patch.called
+
+    # Should call patch_integration_settings with the correct arguments if qbo_credentials.is_expired is False
+    qbo_credentials.is_expired = False
+    qbo_credentials.save()
+
+    invalidate_qbo_credentials(workspace_id)
+
+    args, kwargs = mocked_patch.call_args
+    assert args[0] == workspace_id
+    assert kwargs['is_token_expired'] == True

--- a/tests/test_mappings/test_exceptions.py
+++ b/tests/test_mappings/test_exceptions.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from fyle_integrations_imports.models import ImportLog
 from fyle_integrations_imports.modules.projects import Project
 from apps.workspaces.models import QBOCredential
@@ -8,7 +9,11 @@ from qbosdk.exceptions import InvalidTokenError as QBOInvalidTokenError
 from qbosdk.exceptions import WrongParamsError as QBOWrongParamsError
 
 
-def test_handle_import_exceptions(db):
+def test_handle_import_exceptions(mocker, db):
+
+    mocked_patch = mock.MagicMock()
+    mocker.patch('fyle_qbo_api.utils.patch_integration_settings', side_effect=mocked_patch)
+
     workspace_id = 3
     ImportLog.objects.create(
         workspace_id=workspace_id,
@@ -71,6 +76,9 @@ def test_handle_import_exceptions(db):
     assert import_log.error_log['task'] == 'Import PROJECT to Fyle and Auto Create Mappings'
     assert import_log.error_log['message'] == 'Invalid Token or QBO credentials does not exist workspace_id - 3'
     assert import_log.error_log['alert'] == False
+    args, kwargs = mocked_patch.call_args
+    assert args[0] == workspace_id
+    assert kwargs['is_token_expired'] == True
 
     # QBOInvalidTokenError
     @handle_import_exceptions_v2
@@ -83,6 +91,9 @@ def test_handle_import_exceptions(db):
     assert import_log.error_log['task'] == 'Import PROJECT to Fyle and Auto Create Mappings'
     assert import_log.error_log['message'] == 'Invalid Token or QBO credentials does not exist workspace_id - 3'
     assert import_log.error_log['alert'] == False
+    args, kwargs = mocked_patch.call_args
+    assert args[0] == workspace_id
+    assert kwargs['is_token_expired'] == True
 
     # QBOCredential.DoesNotExist
     @handle_import_exceptions_v2

--- a/tests/test_mappings/test_tasks.py
+++ b/tests/test_mappings/test_tasks.py
@@ -43,6 +43,7 @@ def test_async_auto_map_employees(mocker, db):
     mocker.patch('qbosdk.apis.Employees.get', return_value=[])
     mocker.patch('qbosdk.apis.Vendors.get', return_value=[])
     mocker.patch('fyle_integrations_platform_connector.apis.Employees.sync', return_value=[])
+    mocker.patch('apps.mappings.exceptions.invalidate_qbo_credentials', return_value=None)
     workspace_id = 3
     async_auto_map_employees(workspace_id)
     employee_mappings = EmployeeMapping.objects.filter(workspace_id=workspace_id).count()

--- a/tests/test_quickbooks_online/test_tasks.py
+++ b/tests/test_quickbooks_online/test_tasks.py
@@ -811,7 +811,7 @@ def test_handle_quickbooks_errors(mocker, db):
     task_log = TaskLog.objects.filter(expense_group_id=expense_group.id).first()
 
     mocked_patch = mock.MagicMock()
-    mocker.patch('apps.quickbooks_online.exceptions.patch_integration_settings', side_effect=mocked_patch)
+    mocker.patch('fyle_qbo_api.utils.patch_integration_settings', side_effect=mocked_patch)
 
     handle_quickbooks_error(exception=WrongParamsError(msg='Some Parameters are wrong', response=json.dumps({'error': 'invalid_grant'})), expense_group=expense_group, task_log=task_log, export_type='Bill')
 

--- a/tests/test_quickbooks_online/test_views.py
+++ b/tests/test_quickbooks_online/test_views.py
@@ -70,25 +70,23 @@ def test_get_company_preference_exceptions(api_client, test_connection, mocker, 
 
     api_client.credentials(HTTP_AUTHORIZATION='Bearer {}'.format(access_token))
 
-    mocked_patch = mock.MagicMock()
-    mocker.patch('apps.quickbooks_online.actions.patch_integration_settings', side_effect=mocked_patch)
+    mocked_invalidate = mock.MagicMock()
+    mocker.patch('apps.quickbooks_online.actions.invalidate_qbo_credentials', side_effect=mocked_invalidate)
 
-    with mock.patch('apps.quickbooks_online.utils.QBOConnector.get_company_info') as mock_call:
+    with mock.patch('apps.quickbooks_online.utils.QBOConnector.get_company_preference') as mock_call:
         mock_call.side_effect = WrongParamsError(msg='wrong params', response='invalid_params')
         response = api_client.get(url)
         assert response.status_code == 400
 
-        args, kwargs = mocked_patch.call_args
+        args, _ = mocked_invalidate.call_args
         assert args[0] == 3
-        assert kwargs['is_token_expired'] == True
 
         mock_call.side_effect = InvalidTokenError(msg='Invalid token, try to refresh it', response='Invalid token, try to refresh it')
         response = api_client.get(url)
         assert response.status_code == 400
 
-        args, kwargs = mocked_patch.call_args
+        args, _ = mocked_invalidate.call_args
         assert args[0] == 3
-        assert kwargs['is_token_expired'] == True
 
         mock_call.side_effect = QBOCredential.DoesNotExist()
         response = api_client.get(url)

--- a/tests/test_quickbooks_online/test_views.py
+++ b/tests/test_quickbooks_online/test_views.py
@@ -64,20 +64,31 @@ def test_get_company_preference(mocker, api_client, test_connection, db):
     assert response['Id'] == '1'
 
 
-def test_get_company_preference_exceptions(api_client, test_connection, db):
+def test_get_company_preference_exceptions(api_client, test_connection, mocker, db):
     access_token = test_connection.access_token
     url = '/api/workspaces/3/qbo/preferences/'
 
     api_client.credentials(HTTP_AUTHORIZATION='Bearer {}'.format(access_token))
+
+    mocked_patch = mock.MagicMock()
+    mocker.patch('apps.quickbooks_online.actions.patch_integration_settings', side_effect=mocked_patch)
 
     with mock.patch('apps.quickbooks_online.utils.QBOConnector.get_company_info') as mock_call:
         mock_call.side_effect = WrongParamsError(msg='wrong params', response='invalid_params')
         response = api_client.get(url)
         assert response.status_code == 400
 
+        args, kwargs = mocked_patch.call_args
+        assert args[0] == 3
+        assert kwargs['is_token_expired'] == True
+
         mock_call.side_effect = InvalidTokenError(msg='Invalid token, try to refresh it', response='Invalid token, try to refresh it')
         response = api_client.get(url)
         assert response.status_code == 400
+
+        args, kwargs = mocked_patch.call_args
+        assert args[0] == 3
+        assert kwargs['is_token_expired'] == True
 
         mock_call.side_effect = QBOCredential.DoesNotExist()
         response = api_client.get(url)

--- a/tests/test_workspaces/test_actions.py
+++ b/tests/test_workspaces/test_actions.py
@@ -1,6 +1,8 @@
+import json
+from unittest.mock import MagicMock
 import pytest
 
-from apps.workspaces.actions import post_to_integration_settings
+from apps.workspaces.actions import patch_integration_settings, post_to_integration_settings
 
 
 @pytest.mark.django_db(databases=['default'])
@@ -15,3 +17,49 @@ def test_post_to_integration_settings(mocker):
 
     # If exception is raised, this test will fail
     assert no_exception
+
+
+@pytest.mark.django_db(databases=['default'])
+def test_patch_integration_settings(mocker):
+
+    workspace_id = 1
+    mocked_patch = MagicMock()
+    mocker.patch('apps.fyle.helpers.requests.patch', side_effect=mocked_patch)
+
+    # Test patch request with only errors
+    errors = 7
+    patch_integration_settings(workspace_id, errors)
+
+    expected_payload = {'errors_count': errors, 'tpa_name': 'Fyle Quickbooks Integration'}
+
+    _, kwargs = mocked_patch.call_args
+    actual_payload = json.loads(kwargs['data'])
+
+    assert actual_payload == expected_payload
+
+    # Test patch request with only is_token_expired
+    is_token_expired = True
+    patch_integration_settings(workspace_id, is_token_expired=is_token_expired)
+
+    expected_payload = {'is_token_expired': is_token_expired, 'tpa_name': 'Fyle Quickbooks Integration'}
+
+    _, kwargs = mocked_patch.call_args
+    actual_payload = json.loads(kwargs['data'])
+
+    assert actual_payload == expected_payload
+
+    # Test patch request with errors_count and is_token_expired
+    is_token_expired = True
+    errors = 241
+    patch_integration_settings(workspace_id, errors=errors, is_token_expired=is_token_expired)
+
+    expected_payload = {
+        'errors_count': errors,
+        'is_token_expired': is_token_expired,
+        'tpa_name': 'Fyle Quickbooks Integration'
+    }
+
+    _, kwargs = mocked_patch.call_args
+    actual_payload = json.loads(kwargs['data'])
+
+    assert actual_payload == expected_payload

--- a/tests/test_workspaces/test_actions.py
+++ b/tests/test_workspaces/test_actions.py
@@ -2,7 +2,8 @@ import json
 from unittest.mock import MagicMock
 import pytest
 
-from apps.workspaces.actions import patch_integration_settings, post_to_integration_settings
+from apps.workspaces.actions import post_to_integration_settings
+from fyle_qbo_api.utils import patch_integration_settings
 
 
 @pytest.mark.django_db(databases=['default'])


### PR DESCRIPTION
* feat: patch `/integrations` on export errors

* test: test patch integrations settings api (#737)

* test: test patch integrations settings api

* fix: lint

* feat: patch `/integrations` on token expiry (#738)

* feat: patch `/integrations` on token expiry

* test: patch `/integrations` on qbo token expiry (#739)

* test: patch /integrations on qbo token expiry

* refactor: lint

### Description
Please add PR description here, add screenshots if needed

## Clickup
https://app.clickup.com/t/86cxhftj8
https://app.clickup.com/t/86cxhfutt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new method for creating HTTP PATCH requests to enhance API interactions.
  - Added functions to manage integration settings and invalidate credentials for improved error handling.

- **Refactor**
  - Streamlined error handling logic to automatically invalidate credentials and update integration settings when specific exceptions occur.

- **Tests**
  - Expanded test coverage for new credential management functions and integration settings updates, ensuring robust validation of error handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->