### PR TITLE
fix: skip export v2 edge case

### DIFF
--- a/apps/fyle/tasks.py
+++ b/apps/fyle/tasks.py
@@ -70,7 +70,7 @@ def group_expenses_and_save(expenses: List[Dict], task_log: TaskLog, workspace: 
             expensegroup__isnull=True,
             org_id=workspace.fyle_org_id
         )
-
+    filtered_expenses = [expense for expense in filtered_expenses if not expense.is_skipped]
     ExpenseGroup.create_expense_groups_by_report_id_fund_source(
         filtered_expenses, workspace.id
     )


### PR DESCRIPTION
### Description
- fixed an edge case for skip export v2, where skipped exports came back to export queue

## Clickup
- https://app.clickup.com/t/86cxt989q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced expense grouping so that expenses marked as skipped are no longer included, ensuring more accurate and reliable processing of valid expenses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->