### PR TITLE
fix: use `filter` instead of `get` while invalidating credentials

### DIFF
--- a/fyle_qbo_api/utils.py
+++ b/fyle_qbo_api/utils.py
@@ -57,15 +57,12 @@ def patch_integration_settings(workspace_id: int, errors: int = None, is_token_e
 
 
 def invalidate_qbo_credentials(workspace_id, qbo_credentials=None):
-    try:
-        if not qbo_credentials:
-            qbo_credentials = QBOCredential.objects.filter(workspace_id=workspace_id, is_expired=False, refresh_token__isnull=False).first()
+    if not qbo_credentials:
+        qbo_credentials = QBOCredential.objects.filter(workspace_id=workspace_id, is_expired=False, refresh_token__isnull=False).first()
 
-        if qbo_credentials:
-            if not qbo_credentials.is_expired:
-                patch_integration_settings(workspace_id, is_token_expired=True)
-            qbo_credentials.refresh_token = None
-            qbo_credentials.is_expired = True
-            qbo_credentials.save()
-    except QBOCredential.DoesNotExist:
-        logger.info(f'QBO credentials not found for {workspace_id = }:', )
+    if qbo_credentials:
+        if not qbo_credentials.is_expired:
+            patch_integration_settings(workspace_id, is_token_expired=True)
+        qbo_credentials.refresh_token = None
+        qbo_credentials.is_expired = True
+        qbo_credentials.save()

--- a/fyle_qbo_api/utils.py
+++ b/fyle_qbo_api/utils.py
@@ -59,7 +59,7 @@ def patch_integration_settings(workspace_id: int, errors: int = None, is_token_e
 def invalidate_qbo_credentials(workspace_id, qbo_credentials=None):
     try:
         if not qbo_credentials:
-            qbo_credentials = QBOCredential.get_active_qbo_credentials(workspace_id)
+            qbo_credentials = QBOCredential.objects.filter(workspace_id=workspace_id, is_expired=False, refresh_token__isnull=False).first()
 
         if qbo_credentials:
             if not qbo_credentials.is_expired:


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cy5xqhn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the process for selecting active credentials, ensuring that only valid and non-expired connection tokens are used. This improvement provides more precise control over credential selection and enhances the overall integration reliability.
  
- **New Features**
	- Introduced a dedicated test database (`test_qbo_db`) and a SQL script for loading test data during initialization.
  
- **Chores**
	- Updated the `.flake8` configuration to exclude the `Dockerfile` from linting checks.
	- Removed the `reset_db.sh` script, streamlining the database setup process for tests.
  
- **Bug Fixes**
	- Modified the `db` service in the Docker Compose configuration to replace the data volume with a specific SQL file for database initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->