### PR TITLE
fix: help article domain 

### DIFF
--- a/apps/workspaces/templates/mail_template.html
+++ b/apps/workspaces/templates/mail_template.html
@@ -200,7 +200,7 @@
           </tr>
           <tr>
             <td style="font-size: 14px;line-height: 18px;padding: 35px 24px 0px;color: #2C304E;">
-              You can, easily fix these errors from your integration dashboard. Here's a quick <a href="https://help.fylehq.com/en/articles/6240421-how-to-export-expenses-from-fyle-to-qbo-via-the-integration#h_52f186fcbc"><u style="color: #2C304E;">guide</u></a> on how to resolve errors in the integrations.
+              You can, easily fix these errors from your integration dashboard. Here's a quick <a href="https://www.fylehq.com/help/en/articles/6240421-how-to-export-expenses-from-fyle-to-qbo-via-the-integration#h_52f186fcbc"><u style="color: #2C304E;">guide</u></a> on how to resolve errors in the integrations.
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
### Description
Please add PR description here, add screenshots if needed

## Clickup
[Please add link here](https://app.clickup.com/t/86cxvet4v)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the help guide link in customer emails to point to the correct domain, ensuring users are directed to the proper support article.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->