### PR TITLE
fix: remove bandit from pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,18 +27,6 @@ repos:
       - id: flake8
         additional_dependencies: [flake8-isort, flake8-tidy-imports]
 
-  - repo: https://github.com/pycqa/bandit
-    rev: 1.8.5
-    hooks:
-      - id: bandit
-        name: bandit
-        description: 'Bandit is a tool for finding common security issues in Python code'
-        entry: bandit
-        language: python
-        language_version: python3
-        types: [python]
-        require_serial: true
-
   - repo: local
     hooks:
       - id: flake8


### PR DESCRIPTION
### Description
fix: remove bandit from pre commit

## Clickup
https://app.clickup.com/ 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Bandit security scanning tool from the pre-commit checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->