### PR TITLE
fix: add worker loggers, skip schedule run if task_log is enqueued

### DIFF
--- a/apps/quickbooks_online/queue.py
+++ b/apps/quickbooks_online/queue.py
@@ -127,6 +127,7 @@ def __create_chain_and_run(workspace_id: int, chain_tasks: List[Task], run_in_ra
         chain.append('apps.fyle.tasks.sync_dimensions', workspace_id, True)
 
         for task in chain_tasks:
+            logger.info(f"Executing {task.target} with args {task.args} and kwargs {task.kwargs}")
             chain.append(task.target, *task.args)
 
         chain.run()

--- a/apps/quickbooks_online/tasks.py
+++ b/apps/quickbooks_online/tasks.py
@@ -35,7 +35,7 @@ from apps.quickbooks_online.utils import QBOConnector
 from apps.tasks.models import Error, TaskLog
 from apps.workspaces.models import FyleCredential, QBOCredential, WorkspaceGeneralSettings
 from fyle_qbo_api.exceptions import BulkError
-from fyle_qbo_api.logging_middleware import get_logger
+from fyle_qbo_api.logging_middleware import get_caller_info, get_logger
 from fyle_qbo_api.utils import invalidate_qbo_credentials
 
 logger = logging.getLogger(__name__)
@@ -182,9 +182,11 @@ def create_or_update_employee_mapping(expense_group: ExpenseGroup, qbo_connectio
 
 @handle_qbo_exceptions()
 def create_bill(expense_group_id: int, task_log_id: int, last_export: bool, is_auto_export: bool):
+    called_from = get_caller_info()
+    worker_logger = get_logger()
     task_log = TaskLog.objects.get(id=task_log_id)
     expense_group = ExpenseGroup.objects.get(id=expense_group_id, workspace_id=task_log.workspace_id)
-    logger.info('Creating Bill for Expense Group %s, current state is %s', expense_group.id, task_log.status)
+    worker_logger.info('Creating Bill for Expense Group %s, current state is %s, triggered by %s, called from %s', expense_group.id, task_log.status, task_log.triggered_by, called_from)
 
     if task_log.status not in ['IN_PROGRESS', 'COMPLETE']:
         task_log.status = 'IN_PROGRESS'
@@ -367,9 +369,10 @@ def __validate_expense_group(expense_group: ExpenseGroup, general_settings: Work
 @handle_qbo_exceptions()
 def create_cheque(expense_group_id: int, task_log_id: int, last_export: bool, is_auto_export: bool):
     worker_logger = get_logger()
+    called_from = get_caller_info()
     task_log = TaskLog.objects.get(id=task_log_id)
     expense_group = ExpenseGroup.objects.get(id=expense_group_id, workspace_id=task_log.workspace_id)
-    worker_logger.info('Creating Cheque for Expense Group %s, current state is %s', expense_group.id, task_log.status)
+    worker_logger.info('Creating Cheque for Expense Group %s, current state is %s, triggered by %s, called from %s', expense_group.id, task_log.status, task_log.triggered_by, called_from)
 
     if task_log.status not in ['IN_PROGRESS', 'COMPLETE']:
         task_log.status = 'IN_PROGRESS'
@@ -434,9 +437,10 @@ def create_cheque(expense_group_id: int, task_log_id: int, last_export: bool, is
 @handle_qbo_exceptions()
 def create_qbo_expense(expense_group_id: int, task_log_id: int, last_export: bool, is_auto_export: bool):
     worker_logger = get_logger()
+    called_from = get_caller_info()
     task_log = TaskLog.objects.get(id=task_log_id)
     expense_group = ExpenseGroup.objects.get(id=expense_group_id, workspace_id=task_log.workspace_id)
-    worker_logger.info('Creating QBO Expense for Expense Group %s, current state is %s', expense_group.id, task_log.status)
+    worker_logger.info('Creating QBO Expense for Expense Group %s, current state is %s, triggered by %s, called from %s', expense_group.id, task_log.status, task_log.triggered_by, called_from)
 
     if task_log.status not in ['IN_PROGRESS', 'COMPLETE']:
         task_log.status = 'IN_PROGRESS'
@@ -506,9 +510,10 @@ def create_qbo_expense(expense_group_id: int, task_log_id: int, last_export: boo
 @handle_qbo_exceptions()
 def create_credit_card_purchase(expense_group_id: int, task_log_id: int, last_export: bool, is_auto_export: bool):
     worker_logger = get_logger()
+    called_from = get_caller_info()
     task_log = TaskLog.objects.get(id=task_log_id)
     expense_group = ExpenseGroup.objects.get(id=expense_group_id, workspace_id=task_log.workspace_id)
-    worker_logger.info('Creating Credit Card Purchase for Expense Group %s, current state is %s', expense_group.id, task_log.status)
+    worker_logger.info('Creating Credit Card Purchase for Expense Group %s, current state is %s, triggered by %s, called from %s', expense_group.id, task_log.status, task_log.triggered_by, called_from)
 
     if task_log.status not in ['IN_PROGRESS', 'COMPLETE']:
         task_log.status = 'IN_PROGRESS'
@@ -577,9 +582,10 @@ def create_credit_card_purchase(expense_group_id: int, task_log_id: int, last_ex
 @handle_qbo_exceptions()
 def create_journal_entry(expense_group_id: int, task_log_id: int, last_export: bool, is_auto_export: bool):
     worker_logger = get_logger()
+    called_from = get_caller_info()
     task_log = TaskLog.objects.get(id=task_log_id)
     expense_group = ExpenseGroup.objects.get(id=expense_group_id, workspace_id=task_log.workspace_id)
-    worker_logger.info('Creating Journal Entry for Expense Group %s, current state is %s', expense_group.id, task_log.status)
+    worker_logger.info('Creating Journal Entry for Expense Group %s, current state is %s, triggered by %s, called from %s', expense_group.id, task_log.status, task_log.triggered_by, called_from)
 
     if task_log.status not in ['IN_PROGRESS', 'COMPLETE']:
         task_log.status = 'IN_PROGRESS'

--- a/apps/workspaces/actions.py
+++ b/apps/workspaces/actions.py
@@ -252,6 +252,7 @@ def post_to_integration_settings(workspace_id: int, active: bool):
 
 
 def export_to_qbo(workspace_id, expense_group_ids=[], is_direct_export:bool = False, triggered_by: ExpenseImportSourceEnum = None):
+    logger.info(f"Exporting to QBO for workspace {workspace_id} with expense group ids {expense_group_ids}, triggered by {triggered_by}")
     active_qbo_credentials = QBOCredential.objects.filter(
         workspace_id=workspace_id,
         is_expired=False,

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -105,7 +105,7 @@ def run_sync_schedule(workspace_id):
         logger.info(f"Task log already enqueued for workspace {workspace_id} with count {task_log_enqueued_count}, skipping sync schedule")
         return
 
-    task_log, _ = TaskLog.objects.update_or_create(workspace_id=workspace_id, type='FETCHING_EXPENSES', defaults={'status': 'IN_PROGRESS', 'triggered_by': 'BACKGROUND_SCHEDULE'})
+    task_log, _ = TaskLog.objects.update_or_create(workspace_id=workspace_id, type='FETCHING_EXPENSES', defaults={'status': 'IN_PROGRESS'})
 
     general_settings = WorkspaceGeneralSettings.objects.get(workspace_id=workspace_id)
 

--- a/apps/workspaces/tasks.py
+++ b/apps/workspaces/tasks.py
@@ -97,7 +97,15 @@ def run_sync_schedule(workspace_id):
     :param workspace_id: workspace id
     :return: None
     """
-    task_log, _ = TaskLog.objects.update_or_create(workspace_id=workspace_id, type='FETCHING_EXPENSES', defaults={'status': 'IN_PROGRESS'})
+    logger.info(f"Running sync schedule for workspace {workspace_id}")
+
+    task_log_enqueued_count = TaskLog.objects.filter(workspace_id=workspace_id, status__in=['IN_PROGRESS', 'ENQUEUED']).exclude(type__in=['FETCHING_EXPENSES', 'CREATING_BILL_PAYMENT']).count()
+
+    if task_log_enqueued_count > 0:
+        logger.info(f"Task log already enqueued for workspace {workspace_id} with count {task_log_enqueued_count}, skipping sync schedule")
+        return
+
+    task_log, _ = TaskLog.objects.update_or_create(workspace_id=workspace_id, type='FETCHING_EXPENSES', defaults={'status': 'IN_PROGRESS', 'triggered_by': 'BACKGROUND_SCHEDULE'})
 
     general_settings = WorkspaceGeneralSettings.objects.get(workspace_id=workspace_id)
 


### PR DESCRIPTION
https://app.clickup.com/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved logging across export and sync functions, capturing detailed task execution info, user actions, and trigger sources.

* **Bug Fixes**
  * Added a safeguard to prevent overlapping or redundant sync schedules from running concurrently for the same workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->