### PR TITLE
fix: Tax amount none

### DIFF
--- a/apps/fyle/models.py
+++ b/apps/fyle/models.py
@@ -145,6 +145,9 @@ class Expense(models.Model):
                     'expense_updated_at': expense['expense_updated_at'],
                 }
 
+            if expense['tax_group_id'] is not None and expense['tax_amount'] is None:
+                expense['tax_amount'] = 0
+
             defaults = {
                 'employee_email': expense['employee_email'],
                 'employee_name': expense['employee_name'],

--- a/tests/test_fyle/test_models.py
+++ b/tests/test_fyle/test_models.py
@@ -415,4 +415,4 @@ def test_create_expense_object_tax_amount(db):
         elif expense.expense_id == payload[1]['id']:
             assert expense.tax_amount == 10
         elif expense.expense_id == payload[2]['id']:
-            assert expense.tax_amount == 0
+            assert expense.tax_amount is None

--- a/tests/test_fyle/test_models.py
+++ b/tests/test_fyle/test_models.py
@@ -415,4 +415,4 @@ def test_create_expense_object_tax_amount(db):
         elif expense.expense_id == payload[1]['id']:
             assert expense.tax_amount == 10
         elif expense.expense_id == payload[2]['id']:
-            assert expense.tax_amount is None
+            assert expense.tax_amount == 0


### PR DESCRIPTION
### Description
fix: Tax amount none

## Clickup
https://app.clickup.com/t/86cztddtb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that expenses with a tax group but missing tax amount now have their tax amount set to zero automatically.

* **Tests**
  * Updated tests to reflect that tax amount is set to zero when not provided for expenses with a tax group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->